### PR TITLE
Fix rel attribute bug in external link handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,10 +29,12 @@ document.addEventListener("DOMContentLoaded", function () {
   links.forEach((link) => {
     const href = link.getAttribute("href");
     if (href && href.startsWith("http") && !href.startsWith(baseUrl)) {
-      link.setAttribute("rel", "external no-referrer noopener");
+      link.setAttribute(
+        "rel",
+        "external no-referrer noopener dns-prefetch"
+      );
       link.setAttribute("target", "_blank");
       link.setAttribute("title", "O link irá abrir em uma nova aba");
-      link.setAttribute("rel", "dns-prefetch");
     }
   });
 });


### PR DESCRIPTION
## Summary
- remove duplicate `rel` attribute update in `main.js`
- combine all `rel` values into one call

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461edb333083218961097d45793ea2